### PR TITLE
Add unit testing for YFinance API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -11,5 +11,5 @@ python3 run.py
 
 ```
 cd tests && pip install -r test-requirements.txt
-cd .. && python -m pytest
+cd .. && python3 -m pytest
 ```

--- a/backend/tests/test_yfinance_api.py
+++ b/backend/tests/test_yfinance_api.py
@@ -1,0 +1,45 @@
+import app.utils.app_functions as app_functions
+import app.utils.rebalance as rebalance
+
+
+def test_get_stock_price_stocks():
+    ticker = 'AAPL'
+    response = app_functions.get_stock_price(ticker)
+
+    assert response is not None
+    assert response[0] == ticker
+    assert isinstance(response[1], float)
+
+
+def test_get_stock_price_etfs():
+    ticker = 'VFV.TO'
+    response = app_functions.get_stock_price(ticker)
+
+    assert response is not None
+    assert response[0] == ticker
+    assert isinstance(response[1], float)
+
+
+def test_is_valid_ticker_valid():
+    ticker = 'XEQT.TO'
+    response = app_functions.is_valid_ticker(ticker)
+
+    assert response == True
+
+
+def test_is_valid_ticker_invalid():
+    # Yahoo Finance requires ETFs to have a suffix
+    ticker = 'VFV'
+    response = app_functions.is_valid_ticker(ticker)
+
+    assert response == False
+
+
+def test_fetch_price_and_pe_valid():
+    ticker = 'AAPL'
+    current_price, pe_ratio = rebalance.fetch_price_and_pe(ticker)
+
+    assert current_price is not None
+    assert pe_ratio is not None
+    assert isinstance(current_price, float)
+    assert isinstance(pe_ratio, float)


### PR DESCRIPTION
Due to recent instability with [YFinance API](https://github.com/ranaroussi/yfinance/issues/1729), unit testing is added to ensure the functionality of the API in the provided stock info. 
- Latest release [YFinance 0.2.33](https://pypi.org/project/yfinance/0.2.33/) is currently stable